### PR TITLE
Refactor

### DIFF
--- a/bucky/model/main.py
+++ b/bucky/model/main.py
@@ -247,7 +247,7 @@ class buckyModelCovid:
 
         # reroll model params if we're doing that kind of thing
         self.g_data.Aij.perturb(self.consts.reroll_variance)
-        self.params = self.bucky_params.generate_params(self.consts.reroll_variance)
+        self.params = self.bucky_params.generate_params()
 
         if params is not None:
             self.params = copy.deepcopy(params)

--- a/bucky/model/parameters.py
+++ b/bucky/model/parameters.py
@@ -111,6 +111,7 @@ class buckyParams:
         while True:  # WTB python do-while...
             params = self.reroll_params()
             if self.consts.Te_min < params.Te < params.Tg and params.Ti > self.consts.Ti_min:
+                # TODO use self.consts and self.dists instead of storing these in params
                 params.consts = self.consts
                 params.dists = self.dists
                 return params

--- a/bucky/model/parameters.py
+++ b/bucky/model/parameters.py
@@ -167,7 +167,7 @@ class buckyParams:
 
     def reroll_params(self):
         """Sample each parameter from distribution and calculate derived parameters."""
-        return self.calc_derived_params(dotdict({p: f.get_val() for p, f in self.param_funcs.items()}))
+        return self.calc_derived_params(dotdict({p: f() for p, f in self.param_funcs.items()}))
 
     @staticmethod
     def age_interp(x_bins_new, x_bins, y):

--- a/bucky/model/parameters.py
+++ b/bucky/model/parameters.py
@@ -70,7 +70,7 @@ class buckyParams:
 
         if par_file is not None:
             base_params = self.read_yml(par_file)
-            self.consts = dotdict(base_params["consts"])
+            self.consts = dotdict({k: xp.array(v) for k, v in base_params["consts"].items()})
             self.dists = dotdict(base_params["dists"])
             self._generate_param_funcs(base_params)
 
@@ -79,7 +79,7 @@ class buckyParams:
         self._update_params(base_params)
 
     def _update_params(self, update_dict):
-        self.consts = recursive_dict_update(self.consts, update_dict["consts"])
+        self.consts = recursive_dict_update(self.consts, {k: xp.array(v) for k, v in update_dict["consts"].items()})
         self.dists = recursive_dict_update(self.dists, update_dict["dists"])
         self._generate_param_funcs(update_dict)
 
@@ -95,6 +95,8 @@ class buckyParams:
         while True:  # WTB python do-while...
             params = self.reroll_params()
             if self.consts.Te_min < params.Te < params.Tg and params.Ti > self.consts.Ti_min:
+                params.consts = self.consts
+                params.dists = self.dists
                 return params
             # logging.debug("Rejected params: " + pformat(params))
 

--- a/bucky/model/parameters.py
+++ b/bucky/model/parameters.py
@@ -1,14 +1,13 @@
 """Submodule to handle the model parameterization and randomization"""
-import copy
 import logging
-from pprint import pformat
 
-import numpy  # we only need numpy for interp, we could write this in cupy...
 import yaml
 
 from ..numerical_libs import reimport_numerical_libs, xp
-from ..util import dotdict
-from ..util.distributions import approx_mPERT_sample, truncnorm
+from ..util import dotdict, distributions
+from ..util.distributions import Distribution
+
+from functools import partial
 
 
 def calc_Te(Tg, Ts, n, f):
@@ -65,67 +64,24 @@ class buckyParams:
 
         reimport_numerical_libs("model.parameters.buckyParams.__init__")
 
-        self.eps = xp.array([1e-6])
-        self.one = xp.array([1.0])
+        self.param_funcs = dotdict({})
+        self.consts = dotdict({})
+        self.dists = dotdict({})
 
-        self.par_file = par_file
         if par_file is not None:
-            self.base_params = self.read_yml(par_file)
-            self.base_params = self.preprocess_param_dict(self.base_params)
-            self.consts = dotdict(self.base_params["consts"])
-            self.dists = dotdict(self.base_params["dists"])
-        else:
-            self.base_params = None
+            base_params = self.read_yml(par_file)
+            self.consts = dotdict(base_params["consts"])
+            self.dists = dotdict(base_params["dists"])
+            self._generate_param_funcs(base_params)
 
-    def update_params(self, update_dict):
-        self.base_params = recursive_dict_update(self.base_params, update_dict)
-        self.base_params = self.preprocess_param_dict(self.base_params)
-        self.consts = dotdict(self.base_params["consts"])
-        self.dists = dotdict(self.base_params["dists"])
+    def update_params(self, par_file):
+        base_params = self.read_yml(par_file)
+        self._update_params(base_params)
 
-    # This could be static, literally never uses self
-    def preprocess_param_dict(self, base_params):
-        for k, v in base_params.items():
-            if type(v) == dict:
-                p = k
-                if "values" in base_params[p]:
-                    # params[p] = np.array(base_params[p]["values"])
-                    # params[p] *= truncnorm(1.0, var, size=params[p].shape, a_min=1e-6)
-                    # interp to our age bins
-                    need_interp = True
-                    if xp.array(base_params[p]["age_bins"]).shape == xp.array(base_params["consts"]["age_bins"]).shape:
-                        need_interp = xp.any(xp.array(base_params[p]["age_bins"]) != base_params["consts"]["age_bins"])
-                    else:
-                        need_interp = True
-
-                    if need_interp:
-                        base_params[p]["values"] = self.age_interp(
-                            base_params["consts"]["age_bins"],
-                            base_params[p]["age_bins"],
-                            base_params[p]["values"],
-                        )
-                        base_params[p]["age_bins"] = base_params["consts"]["age_bins"]
-
-                for k2 in v:
-                    to_add = {}
-                    if k2 in ("values", "mean", "CI", "stddev") or k == "consts":
-                        base_params[k][k2] = xp.array(base_params[k][k2])
-                    if "CI" in base_params[k]:
-                        mean, std = CI_to_std(base_params[p]["CI"])
-                        to_add["mean"] = xp.array(mean)
-                        to_add["stddev"] = xp.array(std)
-                    if "clip" in base_params[k]:
-                        clip = base_params[k]["clip"]
-                        to_add["clip_lower"] = xp.array(clip[0]) if clip[0] is not None else None
-                        to_add["clip_upper"] = xp.array(clip[1]) if clip[1] is not None else None
-
-                for k2 in ("CI", "clip"):
-                    if k2 in base_params[k]:
-                        del base_params[k][k2]
-
-                base_params[k].update(to_add)
-
-        return base_params
+    def _update_params(self, update_dict):
+        self.consts = recursive_dict_update(self.consts, update_dict["consts"])
+        self.dists = recursive_dict_update(self.dists, update_dict["dists"])
+        self._generate_param_funcs(update_dict)
 
     @staticmethod
     def read_yml(par_file):
@@ -134,84 +90,91 @@ class buckyParams:
         with open(par_file, "rb") as f:
             return yaml.load(f, yaml.SafeLoader)  # nosec
 
-    def generate_params(self, var=0.2):
+    def generate_params(self):
         """Generate a new set of params by rerolling, adding the derived params and rejecting invalid sets"""
-        if var is None:
-            var = 0.0
         while True:  # WTB python do-while...
-            params = self.reroll_params(self.base_params, var)
-            params = self.calc_derived_params(params)
-            if (params.Te > 1.0 and params.Tg > params.Te and params.Ti > 3.0) or var == 0.0:
+            params = self.reroll_params()
+            if self.consts.Te_min < params.Te < params.Tg and params.Ti > self.consts.Ti_min:
                 return params
             # logging.debug("Rejected params: " + pformat(params))
 
-    def reroll_params(self, base_params, var):
-        """Reroll the parameters defined in the par file"""
-        params = dotdict({})
-        for p in base_params:
-            # Scalars
-            if "gamma" in base_params[p]:
-                mu = copy.deepcopy(base_params[p]["mean"])
-                params[p] = approx_mPERT_sample(mu, gamma=base_params[p]["gamma"])
+    def _generate_param_funcs(self, base_params):
+        # Default standard deviation (as percentage of mean)
+        var = self.consts.reroll_variance if "reroll_variance" in self.consts else 0.2
+        # Existing parameter functions
+        param_funcs = self.param_funcs
 
-            elif "mean" in base_params[p]:
-                if "stddev" in base_params[p]:
-                    if var:
-                        params[p] = truncnorm(
-                            loc=base_params[p]["mean"], scale=base_params[p]["stddev"], a_min=self.eps
-                        )
-                    else:  # just use mean if we set var to 0
-                        params[p] = xp.atleast_1d(copy.deepcopy(base_params[p]["mean"]))
-                else:
-                    params[p] = xp.atleast_1d(copy.deepcopy(base_params[p]["mean"]))
-                    params[p] = params[p] * truncnorm(loc=self.one, scale=var, a_min=self.eps)
+        for p, params in base_params.items():
+            # Collect distribution name
+            if "dist" not in params:
+                continue
+            dist = params.pop("dist")
 
-            # age-based vectors
-            elif "values" in base_params[p]:
-                params[p] = xp.array(base_params[p]["values"])
-                params[p] = params[p] * truncnorm(self.one, var, size=params[p].shape, a_min=self.eps)
-                # interp to our age bins
-                # if xp.any(base_params[p]["age_bins"] != base_params["consts"]["age_bins"]):
-                #    params[p] = self.age_interp(
-                #        base_params["consts"]["age_bins"],
-                #        base_params[p]["age_bins"],
-                #        params[p],
-                #    )
+            # Set default scale if none is specified (could find better method for this)
+            if dist == "truncnorm" and "scale" not in params:
+                params["scale"] = xp.abs(var * xp.array(params["loc"]))
 
-            # fixed values (noop)
+            # Clip function
+            clip = None
+            if "clip" in params:
+                clip = partial(xp.clip, **params.pop("clip"))
+            # Need to clip after interpolation
+            elif "age_bins" in params:
+                a_min = params.get("a_min")
+                a_max = params.get("a_max")
+                clip = partial(xp.clip, a_min=a_min, a_max=a_max)
+
+            # Interpolate function
+            interp = None
+            if "age_bins" in params:
+                standard_age_bins = xp.array(base_params["consts"]["age_bins"])
+                age_bins = xp.array(params.pop("age_bins"))
+                interp = partial(self.age_interp, x_bins_new=standard_age_bins, x_bins=age_bins)
+
+            # Main distribution function
+            if hasattr(distributions, dist):
+                base_func = getattr(distributions, dist)
+            elif hasattr(xp.random, dist):
+                base_func = getattr(xp.random, dist)
             else:
-                params[p] = copy.deepcopy(base_params[p])
+                logging.error("Distribution {} does not exist!".format(dist))
+                continue
 
-            # clip values
-            if "clip" in base_params[p]:
-                clip_lower = base_params[p]["clip_lower"]
-                clip_upper = base_params[p]["clip_upper"]
-                params[p] = xp.clip(params[p], clip_lower, clip_upper)
+            params = {k: xp.array(v) for k, v in params.items()}
 
-        return params
+            param_funcs[p] = Distribution(base_func, params, interp, clip)
+
+    def reroll_params(self):
+        return self.calc_derived_params(dotdict({p: f.get_val() for p, f in self.param_funcs.items()}))
 
     @staticmethod
     def age_interp(x_bins_new, x_bins, y):
         """Interpolate parameters define in age groups to a new set of age groups"""
         # TODO we should probably account for population for the 65+ type bins...
-        x_mean_new = numpy.mean(numpy.array(xp.to_cpu(x_bins_new)), axis=1)
-        x_mean = numpy.mean(numpy.array(xp.to_cpu(x_bins)), axis=1)
-        return numpy.interp(x_mean_new, x_mean, y)
+        x_bins_new = xp.array(x_bins_new)
+        x_bins = xp.array(x_bins)
+        if (x_bins_new.shape != x_bins.shape) or xp.any(x_bins_new != x_bins):
+            x_mean_new = xp.mean(x_bins_new, axis=1)
+            x_mean = xp.mean(x_bins, axis=1)
+            return xp.interp(x_mean_new, x_mean, y)
+        else:
+            return y
 
-    @staticmethod
-    def calc_derived_params(params):
+    def calc_derived_params(self, params):
         """Add the derived params that are calculated from the rerolled ones"""
+        En = self.consts.En
+        Im = self.consts.Im
         params["Te"] = calc_Te(
             params["Tg"],
             params["Ts"],
-            params["consts"]["En"],
+            En,
             params["frac_trans_before_sym"],
         )
-        params["Ti"] = calc_Ti(params["Te"], params["Tg"], params["consts"]["En"])
+        params["Ti"] = calc_Ti(params["Te"], params["Tg"], En)
         r = xp.log(2.0) / params["D"]
         params["R0"] = calc_Reff(
-            params["consts"]["Im"],
-            params["consts"]["En"],
+            Im,
+            En,
             params["Tg"],
             params["Te"],
             r,

--- a/bucky/util/distributions.py
+++ b/bucky/util/distributions.py
@@ -113,8 +113,10 @@ class Distribution:
 
     def get_val(self):
         val = self.base_func(**self.params)
-        if self.interp is not None:
-            val = self.interp(y=val)
         if self.clip is not None:
             val = self.clip(val)
+        if self.interp is not None:
+            val = self.interp(y=val)
+            if self.clip is not None:
+                val = self.clip(val)
         return val

--- a/par/scenario_5.yml
+++ b/par/scenario_5.yml
@@ -13,6 +13,9 @@ consts:
   F_scaling: .9
   rescale_chr: True
 
+  Te_min: 1.
+  Ti_min: 3.
+
 dists:
   Rt_dist:
     mu: 1.
@@ -40,81 +43,105 @@ dists:
 
 Tg:
   # Mean generation interval
-  mean: 7.
+  dist: "truncnorm_from_CI"
   CI: [5.5,8.5]
-  clip: [1, null]
+  a_min: 1.
 
 Ts:
   # Mean serial interval
-  mean: 6.
+  dist: "truncnorm_from_CI"
   CI: [5.,7.]
-  clip: [1., null]
+  a_min: 1.
+
 
 ASYM_FRAC:
   # Fraction of infections that are asymptomatic
-  mean: 0.40
-  clip: [0., 1.]
+  dist: "truncnorm"
+  loc: 0.40
+  a_min: 0.
+  a_max: 1.
+
 
 rel_inf_asym:
   # Relative infectiousness of asymptomatic infections
-  mean: .75
-  clip: [0., 1.]
+  dist: "truncnorm"
+  loc: .75
+  a_min: 0.
+  a_max: 1.
+
 
 frac_trans_before_sym:
   # Fraction of transmissions occuring before symptom onset
-  mean: 0.50
+  dist: "truncnorm"
+  loc: 0.50
   #CI: [0.4, 0.6]
-  clip: [0., 1.]
+  a_min: 0.
+  a_max: 1.
+
 
 F:
   # CFR
+  dist: "truncnorm"
   age_bins: [[0,49], [50,64], [65,100]]
-  values: [0.0005, 0.002, 0.013]
-  clip: [0., 1.]
+  loc: [0.0005, 0.002, 0.013]
+  a_min: 0.
+  a_max: 1.
+
 H:
   # CHR
+  dist: "truncnorm"
   age_bins: [[0,49], [50,64], [65,100]]
-  values: [0.017, 0.045, 0.074]
-  clip: [0., 1.]
+  loc: [0.017, 0.045, 0.074]
+  a_min: 0.
+  a_max: 1.
+
 
 I_TO_H_TIME:
+  dist: "truncnorm"
   age_bins: [[0,49], [50,64], [65,100]]
-  values: [6., 6., 4.]
-  stddev: [5.0, 5.3, 5.7]
-  clip: [1., null]
+  loc: [6., 6., 4.]
+  scale: [5.0, 5.3, 5.7]
+  a_min: 1.
 
 H_TIME:
   # TODO this needs to be calced as the weighted avg of the icu and non icu params in the new planning doc
+  dist: "truncnorm"
   age_bins: [[0,49], [50,64], [65,100]]
-  values: [4.9, 7.6, 8.1]
-  #stddev: [3.7, 4.3, 5.1]
-  clip: [1., null]
+  loc: [4.9, 7.6, 8.1]
+  #scale: [3.7, 4.3, 5.1]
+  a_min: 1.
 
 ICU_TIME:
+  dist: "truncnorm"
   age_bins: [[0,49], [50,64], [65,100]]
-  values: [9.5, 10.5, 10.0]
-  stddev: [7.2, 7.0, 6.8]
-  clip: [1., null]
+  loc: [9.5, 10.5, 10.0]
+  scale: [7.2, 7.0, 6.8]
+  a_min: 1.
 
 ICU_FRAC:
+  dist: "truncnorm"
   age_bins: [[0,49], [50,64], [65,100]]
-  values: [.238, .361, .353]
-  clip: [0., 1.]
+  loc: [.238, .361, .353]
+  a_min: 0.
+  a_max: 1.
 
 ICU_VENT_FRAC:
+  dist: "truncnorm"
   age_bins: [[0,49], [50,64], [65,100]]
-  values: [.721, .776, .755]
-  clip: [0., 1.]
+  loc: [.721, .776, .755]
+  a_min: 0.
+  a_max: 1.
 
 D_REPORT_TIME:
+  dist: "truncnorm"
   age_bins: [[0,49], [50,64], [65,100]]
-  values: [7.1, 7.2, 6.6]
-  stddev: [7.7, 7.7, 7.3]
-  clip: [0., null]
+  loc: [7.1, 7.2, 6.6]
+  scale: [7.7, 7.7, 7.3]
+  a_min: 0.
 
 D:
   # NB: This isn't used anymore
   # Doubling time (this is now calced from data but the way parameters.py works means it needs an initial value. it will be refactored out)
-  mean: 150
+  dist: "truncnorm_from_CI"
   CI: [130.5, 170.5]
-  clip: [0, null]
+  a_min: 0.


### PR DESCRIPTION
Summary of changes:

- par_file can now point to a directory. Files in the directory will be read in alphanumeric order and most recent value of any duplicated parameter will be used 
- parameter distributions are specified with "dist" in the parameter file. All options (except for "age_bins" and "clip") will be passed as arguments to the named distribution function. 
- If "clip" is specified, values sampled from the distribution are clipped to range
- If "age_bins" is specified, values are interpolated to match consts.age_bins, and an additional clip step is added to make sure interpolated values also lie within allowed range 

